### PR TITLE
feat(seller-profile): allow client/seller to view seller profiles and…

### DIFF
--- a/backend/src/controllers/seller.controller.js
+++ b/backend/src/controllers/seller.controller.js
@@ -89,6 +89,49 @@ class SellerController {
       });
     }
   }
+
+  async getVisibleSellers(req, res, next) {
+    try {
+      const sellers = await sellerService.getVisibleSellers();
+      return res.status(200).json({
+        success: true,
+        data: sellers,
+      });
+    } catch (error) {
+      if (typeof next === "function") return next(error);
+      return res.status(500).json({ success: false, message: "Failed to retrieve sellers" });
+    }
+  }
+
+  async getSellerProfileById(req, res, next) {
+    try {
+      const seller = await sellerService.getSellerPublicProfile(req.params.sellerId);
+      return res.status(200).json({
+        success: true,
+        data: seller,
+      });
+    } catch (error) {
+      if (typeof next === "function") return next(error);
+      return res.status(error.statusCode || 500).json({ success: false, message: error.message });
+    }
+  }
+
+  async getSellerProducts(req, res, next) {
+    try {
+      const products = await sellerService.getSellerPublicProducts(
+        req.params.sellerId,
+        req.query.type || "remaining"
+      );
+
+      return res.status(200).json({
+        success: true,
+        data: products,
+      });
+    } catch (error) {
+      if (typeof next === "function") return next(error);
+      return res.status(error.statusCode || 500).json({ success: false, message: error.message });
+    }
+  }
 }
 
 module.exports = new SellerController();

--- a/backend/src/middlewares/auth.middleware.js
+++ b/backend/src/middlewares/auth.middleware.js
@@ -51,4 +51,17 @@ const isSeller = async (req, res, next) => {
   return res.status(403).json({ error: "Denied Access: sellers only" });
 };
 
-module.exports = { authenticate, isAdmin, isSeller };
+const isClientOrSeller = (req, res, next) => {
+  const roles = req.user?.role;
+
+  if (
+    Array.isArray(roles) &&
+    (roles.includes("client") || roles.includes("seller"))
+  ) {
+    return next();
+  }
+
+  return res.status(403).json({ error: "Denied Access: clients or sellers only" });
+};
+
+module.exports = { authenticate, isAdmin, isSeller, isClientOrSeller };

--- a/backend/src/repositories/product.repository.js
+++ b/backend/src/repositories/product.repository.js
@@ -68,6 +68,21 @@ const searchByCategory = async (categoryName) => {
 
 const countByFilter = (filter = {}) => Product.countDocuments(filter);
 
+const findSellerProducts = (sellerId, type = "remaining") => {
+    const filter = {
+        seller: sellerId,
+        isApproved: true,
+    };
+
+    if (type === "remaining") {
+        filter.isAvailable = true;
+    } else if (type === "sold") {
+        filter.isAvailable = false;
+    }
+
+    return Product.find(filter).sort({ createdAt: -1 });
+};
+
 
 
 module.exports = { 
@@ -82,4 +97,5 @@ module.exports = {
     searchByName, 
     searchByCategory,
     countByFilter,
+    findSellerProducts,
 };

--- a/backend/src/repositories/seller.repository.js
+++ b/backend/src/repositories/seller.repository.js
@@ -20,9 +20,16 @@ const findByIdWithUser = async (id) => {
   return Seller.findById(id).populate("userId", "firstName lastName email");
 };
 
+const findAllWithUser = async () => {
+  return Seller.find()
+    .populate("userId", "firstName lastName email")
+    .sort({ createdAt: -1 });
+};
+
 module.exports = {
   createSellerProfile,
   findByUserId,
   findByUserIdWithUser,
   findByIdWithUser,
+  findAllWithUser,
 };

--- a/backend/src/routes/public.routes.js
+++ b/backend/src/routes/public.routes.js
@@ -4,7 +4,8 @@ const { getProducts, findProductById , filterByPrice , getNewstProducts ,
 const { isAvailable } = require('../middlewares/availableProduct.middleware');
 const router = express.Router();
 const authController = require("../controllers/auth.controller");
-const { authenticate } = require("../middlewares/auth.middleware");
+const sellerController = require("../controllers/seller.controller");
+const { authenticate, isClientOrSeller } = require("../middlewares/auth.middleware");
 const { registerSchema, loginSchema, emailSchema, resetPasswordSchema } = require("../validators/auth.validator");
 const validate = require("../middlewares/validate.middleware");
 const categoryController = require("../controllers/category.controller");
@@ -30,10 +31,17 @@ router.get("/activate/:token", authController.activateAccount);
 // Protected
 router.get("/verify-token", authenticate, authController.verifyToken);
 router.get("/me", authenticate, authController.getCurrentUser);
+router.get("/sellers", authenticate, isClientOrSeller, sellerController.getVisibleSellers);
+router.get("/sellers/:sellerId", authenticate, isClientOrSeller, sellerController.getSellerProfileById);
+router.get(
+  "/sellers/:sellerId/products",
+  authenticate,
+  isClientOrSeller,
+  sellerController.getSellerProducts
+);
 
 
 module.exports = router;
-
 
 
 

--- a/backend/src/services/seller.service.js
+++ b/backend/src/services/seller.service.js
@@ -1,7 +1,31 @@
 const userRepo = require("../repositories/user.repository");
 const sellerRepo = require("../repositories/seller.repository");
+const productRepo = require("../repositories/product.repository");
+const mongoose = require("mongoose");
 
 class SellerService {
+  formatPublicSellerProfile(seller) {
+    return {
+      _id: seller._id,
+      userId: seller.userId?._id || seller.userId,
+      fullName: seller.userId
+        ? `${seller.userId.firstName || ""} ${seller.userId.lastName || ""}`.trim()
+        : "",
+      firstName: seller.userId?.firstName,
+      lastName: seller.userId?.lastName,
+      email: seller.userId?.email,
+      description: seller.description,
+      profileUrl: seller.profileUrl,
+      bannerUrl: seller.bannerUrl,
+      address: seller.address,
+      isVerified: seller.isVerified,
+      rating: seller.rating,
+      totalSales: seller.totalSales,
+      createdAt: seller.createdAt,
+      updatedAt: seller.updatedAt,
+    };
+  }
+
   /**
    * Switch a user to seller role and create seller profile
    * @param {string} userId - The user's ID
@@ -78,6 +102,51 @@ class SellerService {
   async isUserSeller(userId) {
     const user = await userRepo.findById(userId);
     return user && user.role.includes("seller");
+  }
+
+  async getVisibleSellers() {
+    const sellers = await sellerRepo.findAllWithUser();
+    return sellers.map((seller) => this.formatPublicSellerProfile(seller));
+  }
+
+  async getSellerPublicProfile(sellerId) {
+    if (!mongoose.Types.ObjectId.isValid(sellerId)) {
+      const error = new Error("Invalid seller id");
+      error.statusCode = 400;
+      throw error;
+    }
+
+    const seller = await sellerRepo.findByIdWithUser(sellerId);
+    if (!seller) {
+      const error = new Error("Seller profile not found");
+      error.statusCode = 404;
+      throw error;
+    }
+
+    return this.formatPublicSellerProfile(seller);
+  }
+
+  async getSellerPublicProducts(sellerId, type = "remaining") {
+    if (!mongoose.Types.ObjectId.isValid(sellerId)) {
+      const error = new Error("Invalid seller id");
+      error.statusCode = 400;
+      throw error;
+    }
+
+    if (type !== "remaining" && type !== "sold") {
+      const error = new Error("Invalid type. Use 'remaining' or 'sold'");
+      error.statusCode = 400;
+      throw error;
+    }
+
+    const seller = await sellerRepo.findByIdWithUser(sellerId);
+    if (!seller) {
+      const error = new Error("Seller profile not found");
+      error.statusCode = 404;
+      throw error;
+    }
+
+    return productRepo.findSellerProducts(sellerId, type);
   }
 }
 


### PR DESCRIPTION
Added seller profile viewing endpoints for authenticated users (client and seller roles only).
Implemented GET /api/sellers to list visible sellers.
Implemented GET /api/sellers/:sellerId to fetch public seller profile details.
Implemented GET /api/sellers/:sellerId/products?type=remaining|sold for seller product tabs.
Added role guard isClientOrSeller in auth middleware.
Filtered sensitive seller data (e.g., bankAccount) from public responses.
Added validation and proper error handling for invalid IDs/types (400), unauthorized access (401/403), and missing sellers (404).
Closes #31 